### PR TITLE
Handle Gemfiles that only specify minor version

### DIFF
--- a/spec/fixtures/gemfiles/minor_version_specified
+++ b/spec/fixtures/gemfiles/minor_version_specified
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "business", "~> 1.4"
+gem "statesman", "~> 1.2"


### PR DESCRIPTION
Step 1: keep the same level of precision for the updated version.
