### PR TITLE
Bump webmock to 1.22.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "shoryuken", "~> 2.0.0"
 group :development do
   gem "rspec", "~> 3.3.0"
   gem "rspec-its", "~> 1.2.0"
-  gem "webmock", "~> 1.21.0"
+  gem "webmock", "~> 1.22.1"
   gem "rubocop", "~> 0.34.2"
   gem "foreman"
   gem "fake_sqs", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ GEM
       thor (~> 0.19.1)
     gemnasium-parser (0.1.9)
     gems (0.8.3)
+    hashdiff (0.2.2)
     hitimes (1.2.3)
     jmespath (1.1.3)
     json (1.8.3)
@@ -85,9 +86,10 @@ GEM
     tilt (2.0.1)
     timers (4.0.4)
       hitimes
-    webmock (1.21.0)
+    webmock (1.22.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -107,7 +109,7 @@ DEPENDENCIES
   rubocop (~> 0.34.2)
   sentry-raven (~> 0.15.2)
   shoryuken (~> 2.0.0)
-  webmock (~> 1.21.0)
+  webmock (~> 1.22.1)
 
 BUNDLED WITH
    1.10.6


### PR DESCRIPTION
Bumps [webmock](https://github.com/bblimke/webmock) to 1.22.1
- [Changelog](https://github.com/bblimke/webmock/blob/master/CHANGELOG.md)
- [Commits](https://github.com/bblimke/webmock/commits)
