### PR TITLE
Bump shoryuken to 2.0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "prius", "~> 1.0.0"
 gem "gems", "~> 0.8.3"
 gem "sentry-raven", "~> 0.15.2"
 gem "bundler", "~> 1.10.6"
-gem "shoryuken", "~> 2.0.0"
+gem "shoryuken", "~> 2.0.2"
 
 group :development do
   gem "rspec", "~> 3.3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
       faraday (~> 0.8, < 0.10)
     sentry-raven (0.15.2)
       faraday (>= 0.7.6)
-    shoryuken (2.0.1)
+    shoryuken (2.0.2)
       aws-sdk-core (~> 2)
       celluloid (~> 0.16.0)
     sinatra (1.4.6)
@@ -105,7 +105,7 @@ DEPENDENCIES
   rspec-its (~> 1.2.0)
   rubocop (~> 0.34.2)
   sentry-raven (~> 0.15.2)
-  shoryuken (~> 2.0.0)
+  shoryuken (~> 2.0.2)
   webmock (~> 1.22.2)
 
 BUNDLED WITH


### PR DESCRIPTION
Bumps [shoryuken](https://github.com/phstc/shoryuken) to 2.0.2
- [Changelog](https://github.com/phstc/shoryuken/blob/master/CHANGELOG.md)
- [Commits](https://github.com/phstc/shoryuken/commits)