### PR TITLE
Bump webmock to 1.22.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "shoryuken", "~> 2.0.0"
 group :development do
   gem "rspec", "~> 3.3.0"
   gem "rspec-its", "~> 1.2.0"
-  gem "webmock", "~> 1.22.1"
+  gem "webmock", "~> 1.22.2"
   gem "rubocop", "~> 0.34.2"
   gem "highline", "~> 1.7.8"
   gem "foreman", "~> 0.78.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     tilt (2.0.1)
     timers (4.0.4)
       hitimes
-    webmock (1.22.1)
+    webmock (1.22.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -106,7 +106,7 @@ DEPENDENCIES
   rubocop (~> 0.34.2)
   sentry-raven (~> 0.15.2)
   shoryuken (~> 2.0.0)
-  webmock (~> 1.22.1)
+  webmock (~> 1.22.2)
 
 BUNDLED WITH
    1.10.6


### PR DESCRIPTION
Bumps [webmock](https://github.com/bblimke/webmock) to 1.22.2
- [Changelog](https://github.com/bblimke/webmock/blob/master/CHANGELOG.md)
- [Commits](https://github.com/bblimke/webmock/commits)