### PR TITLE
Bump aws-sdk to 2.1.33

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "shoryuken", "~> 2.0.2"
 group :development do
   gem "rspec", "~> 3.3.0"
   gem "rspec-its", "~> 1.2.0"
-  gem "webmock", "~> 1.22.2"
+  gem "webmock", "~> 1.22.1"
   gem "rubocop", "~> 0.34.2"
   gem "highline", "~> 1.7.8"
   gem "foreman", "~> 0.78.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,12 +5,12 @@ GEM
     ast (2.1.0)
     astrolabe (1.3.1)
       parser (~> 2.2)
-    aws-sdk (2.1.31)
-      aws-sdk-resources (= 2.1.31)
-    aws-sdk-core (2.1.31)
+    aws-sdk (2.1.33)
+      aws-sdk-resources (= 2.1.33)
+    aws-sdk-core (2.1.33)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.1.31)
-      aws-sdk-core (= 2.1.31)
+    aws-sdk-resources (2.1.33)
+      aws-sdk-core (= 2.1.33)
     builder (3.2.2)
     celluloid (0.16.0)
       timers (~> 4.0.0)
@@ -106,7 +106,7 @@ DEPENDENCIES
   rubocop (~> 0.34.2)
   sentry-raven (~> 0.15.2)
   shoryuken (~> 2.0.2)
-  webmock (~> 1.22.2)
+  webmock (~> 1.22.1)
 
 BUNDLED WITH
    1.10.6


### PR DESCRIPTION
Bumps [aws-sdk](https://github.com/aws/aws-sdk-ruby) to 2.1.33
- [Changelog](https://github.com/aws/aws-sdk-ruby/blob/master/CHANGELOG.md)
- [Commits](https://github.com/aws/aws-sdk-ruby/commits)