### PR TITLE
Better error handling

### DIFF
--- a/app/workers/dependency_file_fetcher.rb
+++ b/app/workers/dependency_file_fetcher.rb
@@ -12,7 +12,8 @@ module Workers
     shoryuken_options(
       queue: "bump-repos_to_fetch_files_for",
       body_parser: :json,
-      auto_delete: true
+      auto_delete: true,
+      retry_intervals: [60, 300, 3_600, 36_000] # specified in seconds
     )
 
     def perform(_sqs_message, body)

--- a/app/workers/dependency_file_parser.rb
+++ b/app/workers/dependency_file_parser.rb
@@ -16,7 +16,7 @@ module Workers
       auto_delete: true
     )
 
-    def perform(_sqs_message, body)
+    def perform(sqs_message, body)
       parser = parser_for(body["repo"]["language"])
       dependency_files = body["dependency_files"].map do |file|
         DependencyFile.new(name: file["name"], content: file["content"])
@@ -32,6 +32,7 @@ module Workers
       end
     rescue => error
       Raven.capture_exception(error, extra: { body: body })
+      sqs_message.delete
       raise
     end
 

--- a/app/workers/update_checker.rb
+++ b/app/workers/update_checker.rb
@@ -17,7 +17,7 @@ module Workers
       auto_delete: true
     )
 
-    def perform(_sqs_message, body)
+    def perform(sqs_message, body)
       dependency = Dependency.new(name: body["dependency"]["name"],
                                   version: body["dependency"]["version"])
       dependency_files = body["dependency_files"].map do |file|
@@ -36,6 +36,7 @@ module Workers
                                        version: update_checker.latest_version))
     rescue => error
       Raven.capture_exception(error, extra: { body: body })
+      sqs_message.delete
       raise
     end
 

--- a/spec/app/workers/dependency_file_parser_spec.rb
+++ b/spec/app/workers/dependency_file_parser_spec.rb
@@ -3,7 +3,7 @@ require "./app/workers/dependency_file_parser"
 
 RSpec.describe Workers::DependencyFileParser do
   subject(:worker) { described_class.new }
-  let(:sqs_message) { double("sqs_message") }
+  let(:sqs_message) { double("sqs_message", delete: true) }
   let(:body) do
     {
       "repo" => {

--- a/spec/app/workers/update_checker_spec.rb
+++ b/spec/app/workers/update_checker_spec.rb
@@ -3,7 +3,7 @@ require "./app/workers/update_checker"
 
 RSpec.describe Workers::UpdateChecker do
   let(:worker) { described_class.new }
-  let(:sqs_message) { double("sqs_message") }
+  let(:sqs_message) { double("sqs_message", delete: true) }
   let(:body) do
     {
       "repo" => {


### PR DESCRIPTION
Currently, if `Workers::DependencyFileFetcher`, `Workers::DependencyFileParser` or ``Workers::UpdateChecker` fail then they will attempt to retry themselves immediately, and indefinitely.