### PR TITLE
Bump sentry-raven to 0.15.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem "gemnasium-parser", "~> 0.1.9"
 gem "octokit", "~> 4.2.0"
 gem "prius", "~> 1.0.0"
 gem "gems", "~> 0.8.3"
-gem "sentry-raven", "~> 0.15.4"
+gem "sentry-raven", "~> 0.15.5"
 gem "bundler", "~> 1.11.2"
 gem "shoryuken", "~> 2.0.3"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
     sawyer (0.6.0)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
-    sentry-raven (0.15.4)
+    sentry-raven (0.15.5)
       faraday (>= 0.7.6)
     shoryuken (2.0.3)
       aws-sdk-core (~> 2)
@@ -116,7 +116,7 @@ DEPENDENCIES
   rspec (~> 3.4.0)
   rspec-its (~> 1.2.0)
   rubocop (~> 0.36.0)
-  sentry-raven (~> 0.15.4)
+  sentry-raven (~> 0.15.5)
   shoryuken (~> 2.0.3)
   webmock (~> 1.22.6)
 


### PR DESCRIPTION
Bumps [sentry-raven](https://github.com/getsentry/raven-ruby) to 0.15.5.
- [Changelog](https://github.com/getsentry/raven-ruby/blob/master/changelog.md)
- [Commits](https://github.com/getsentry/raven-ruby/commits)