### PR TITLE
Bump webmock to 1.24.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "shoryuken", "~> 2.0.3"
 group :development do
   gem "rspec", "~> 3.4.0"
   gem "rspec-its", "~> 1.2.0"
-  gem "webmock", "~> 1.22.6"
+  gem "webmock", "~> 1.24.0"
   gem "rubocop", "~> 0.36.0"
   gem "highline", "~> 1.7.8"
   gem "foreman", "~> 0.78.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ GEM
       thor (~> 0.19.1)
     gemnasium-parser (0.1.9)
     gems (0.8.3)
-    hashdiff (0.2.3)
+    hashdiff (0.3.0)
     highline (1.7.8)
     hitimes (1.2.3)
     jmespath (1.1.3)
@@ -94,7 +94,7 @@ GEM
     tilt (2.0.2)
     timers (4.1.1)
       hitimes
-    webmock (1.22.6)
+    webmock (1.24.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -118,7 +118,7 @@ DEPENDENCIES
   rubocop (~> 0.36.0)
   sentry-raven (~> 0.15.4)
   shoryuken (~> 2.0.3)
-  webmock (~> 1.22.6)
+  webmock (~> 1.24.0)
 
 BUNDLED WITH
    1.11.2


### PR DESCRIPTION
Bumps [webmock](https://github.com/bblimke/webmock) to 1.24.0.
- [Changelog](https://github.com/bblimke/webmock/blob/master/CHANGELOG.md)
- [Commits](https://github.com/bblimke/webmock/commits)