### PR TITLE
Bump shoryuken to 2.0.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "prius", "~> 1.0.0"
 gem "gems", "~> 0.8.3"
 gem "sentry-raven", "~> 0.15.4"
 gem "bundler", "~> 1.11.2"
-gem "shoryuken", "~> 2.0.3"
+gem "shoryuken", "~> 2.0.4"
 
 group :development do
   gem "rspec", "~> 3.4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
       faraday (~> 0.8, < 0.10)
     sentry-raven (0.15.4)
       faraday (>= 0.7.6)
-    shoryuken (2.0.3)
+    shoryuken (2.0.4)
       aws-sdk-core (~> 2)
       celluloid (~> 0.16)
     sinatra (1.4.7)
@@ -117,7 +117,7 @@ DEPENDENCIES
   rspec-its (~> 1.2.0)
   rubocop (~> 0.36.0)
   sentry-raven (~> 0.15.4)
-  shoryuken (~> 2.0.3)
+  shoryuken (~> 2.0.4)
   webmock (~> 1.22.6)
 
 BUNDLED WITH


### PR DESCRIPTION
Bumps [shoryuken](https://github.com/phstc/shoryuken) to 2.0.4.
- [Changelog](https://github.com/phstc/shoryuken/blob/master/CHANGELOG.md)
- [Commits](https://github.com/phstc/shoryuken/commits)