### PR TITLE
Bump rubocop to 0.37.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development do
   gem "rspec", "~> 3.4.0"
   gem "rspec-its", "~> 1.2.0"
   gem "webmock", "~> 1.24.0"
-  gem "rubocop", "~> 0.36.0"
+  gem "rubocop", "~> 0.37.2"
   gem "highline", "~> 1.7.8"
   gem "foreman", "~> 0.78.0"
   gem "fake_sqs", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.8)
-    ast (2.2.0)
     aws-sdk (2.2.13)
       aws-sdk-resources (= 2.2.13)
     aws-sdk-core (2.2.13)
@@ -47,14 +46,10 @@ GEM
     multipart-post (2.0.0)
     octokit (4.2.0)
       sawyer (~> 0.6.0, >= 0.5.3)
-    parser (2.3.0.2)
-      ast (~> 2.2)
-    powerpack (0.1.1)
     prius (1.0.0)
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
-    rainbow (2.1.0)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -71,12 +66,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
-    rubocop (0.36.0)
-      parser (>= 2.3.0.0, < 3.0)
-      powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
-      ruby-progressbar (~> 1.7)
-    ruby-progressbar (1.7.5)
     safe_yaml (1.0.4)
     sawyer (0.6.0)
       addressable (~> 2.3.5)
@@ -115,10 +104,7 @@ DEPENDENCIES
   prius (~> 1.0.0)
   rspec (~> 3.4.0)
   rspec-its (~> 1.2.0)
-  rubocop (~> 0.36.0)
+  rubocop (~> 0.37.2)
   sentry-raven (~> 0.15.5)
   shoryuken (~> 2.0.3)
   webmock (~> 1.24.0)
-
-BUNDLED WITH
-   1.11.2


### PR DESCRIPTION
Bumps [rubocop](https://github.com/bbatsov/rubocop) to 0.37.2.
- [Changelog](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md)
- [Commits](https://github.com/bbatsov/rubocop/commits)