### PR TITLE
Bump shoryuken to 2.0.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "prius", "~> 1.0.0"
 gem "gems", "~> 0.8.3"
 gem "sentry-raven", "~> 0.15.5"
 gem "bundler", "~> 1.11.2"
-gem "shoryuken", "~> 2.0.3"
+gem "shoryuken", "~> 2.0.4"
 
 group :development do
   gem "rspec", "~> 3.4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,28 +5,9 @@ GEM
     ast (2.2.0)
     aws-sdk (2.2.13)
       aws-sdk-resources (= 2.2.13)
-    aws-sdk-core (2.2.13)
-      jmespath (~> 1.0)
     aws-sdk-resources (2.2.13)
       aws-sdk-core (= 2.2.13)
     builder (3.2.2)
-    celluloid (0.17.3)
-      celluloid-essentials
-      celluloid-extras
-      celluloid-fsm
-      celluloid-pool
-      celluloid-supervision
-      timers (>= 4.1.1)
-    celluloid-essentials (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-extras (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-fsm (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-pool (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-supervision (0.20.5)
-      timers (>= 4.1.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
@@ -42,8 +23,6 @@ GEM
     gems (0.8.3)
     hashdiff (0.3.0)
     highline (1.7.8)
-    hitimes (1.2.3)
-    jmespath (1.1.3)
     multipart-post (2.0.0)
     octokit (4.2.0)
       sawyer (~> 0.6.0, >= 0.5.3)
@@ -83,17 +62,12 @@ GEM
       faraday (~> 0.8, < 0.10)
     sentry-raven (0.15.5)
       faraday (>= 0.7.6)
-    shoryuken (2.0.3)
-      aws-sdk-core (~> 2)
-      celluloid (~> 0.16)
     sinatra (1.4.7)
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
     thor (0.19.1)
     tilt (2.0.2)
-    timers (4.1.1)
-      hitimes
     webmock (1.24.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -117,8 +91,5 @@ DEPENDENCIES
   rspec-its (~> 1.2.0)
   rubocop (~> 0.36.0)
   sentry-raven (~> 0.15.5)
-  shoryuken (~> 2.0.3)
+  shoryuken (~> 2.0.4)
   webmock (~> 1.24.0)
-
-BUNDLED WITH
-   1.11.2


### PR DESCRIPTION
Bumps [shoryuken](https://github.com/phstc/shoryuken) to 2.0.4.
- [Changelog](https://github.com/phstc/shoryuken/blob/master/CHANGELOG.md)
- [Commits](https://github.com/phstc/shoryuken/commits)