### PR TITLE
Bump aws-sdk to 2.2.18

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,12 +3,6 @@ GEM
   specs:
     addressable (2.3.8)
     ast (2.2.0)
-    aws-sdk (2.2.13)
-      aws-sdk-resources (= 2.2.13)
-    aws-sdk-core (2.2.13)
-      jmespath (~> 1.0)
-    aws-sdk-resources (2.2.13)
-      aws-sdk-core (= 2.2.13)
     builder (3.2.2)
     celluloid (0.17.3)
       celluloid-essentials
@@ -43,7 +37,6 @@ GEM
     hashdiff (0.3.0)
     highline (1.7.8)
     hitimes (1.2.3)
-    jmespath (1.1.3)
     multipart-post (2.0.0)
     octokit (4.2.0)
       sawyer (~> 0.6.0, >= 0.5.3)
@@ -119,6 +112,3 @@ DEPENDENCIES
   sentry-raven (~> 0.15.5)
   shoryuken (~> 2.0.3)
   webmock (~> 1.24.0)
-
-BUNDLED WITH
-   1.11.2


### PR DESCRIPTION
Bumps [aws-sdk](https://github.com/aws/aws-sdk-ruby) to 2.2.18.
- [Changelog](https://github.com/aws/aws-sdk-ruby/blob/master/CHANGELOG.md)
- [Commits](https://github.com/aws/aws-sdk-ruby/commits)