### PR TITLE
Bump rubocop to 0.37.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :development do
   gem "rspec", "~> 3.4.0"
   gem "rspec-its", "~> 1.2.0"
   gem "webmock", "~> 1.24.0"
-  gem "rubocop", "~> 0.36.0"
+  gem "rubocop", "~> 0.37.2"
   gem "foreman", "~> 0.78.0"
   gem "dotenv", require: false
   gem "highline", "~> 1.7.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.8)
-    ast (2.2.0)
     concurrent-ruby (1.0.0)
     connection_pool (2.2.0)
     crack (0.4.3)
@@ -20,14 +19,10 @@ GEM
     multipart-post (2.0.0)
     octokit (4.2.0)
       sawyer (~> 0.6.0, >= 0.5.3)
-    parser (2.3.0.2)
-      ast (~> 2.2)
-    powerpack (0.1.1)
     prius (1.0.0)
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
-    rainbow (2.1.0)
     redis (3.2.2)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
@@ -45,12 +40,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
-    rubocop (0.36.0)
-      parser (>= 2.3.0.0, < 3.0)
-      powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
-      ruby-progressbar (~> 1.7)
-    ruby-progressbar (1.7.5)
     safe_yaml (1.0.4)
     sawyer (0.6.0)
       addressable (~> 2.3.5)
@@ -86,11 +75,8 @@ DEPENDENCIES
   prius (~> 1.0.0)
   rspec (~> 3.4.0)
   rspec-its (~> 1.2.0)
-  rubocop (~> 0.36.0)
+  rubocop (~> 0.37.2)
   sentry-raven (~> 0.15.5)
   sidekiq (~> 4.1.0)
   sinatra
   webmock (~> 1.24.0)
-
-BUNDLED WITH
-   1.11.2


### PR DESCRIPTION
Bumps [rubocop](https://github.com/bbatsov/rubocop) to 0.37.2.
- [Changelog](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md)
- [Commits](https://github.com/bbatsov/rubocop/commits)