### PR TITLE
Use a fork of Heroku's Ruby buildpack to work around Bundler issues

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
       "url": "https://github.com/heroku/heroku-buildpack-nodejs"
     },
     {
-      "url": "https://github.com/heroku/heroku-buildpack-ruby"
+      "url": "https://github.com/hmac/heroku-buildpack-ruby"
     }
   ],
   "env": {


### PR DESCRIPTION
Heroku's Ruby buildpack sets the Bundler configuration `BUNDLE_FROZEN=1`.
While intended to prevent the app's Gemfile.lock from being modified,
this has the side effect of preventing Bump from using the Bundler gem
to generate new lockfiles as part of its process of bumping
dependencies.

This commit changes the default configuration to use a fork of Heroku's
buildpack which sets `BUNDLE_FROZEN=0` at the end of the deployment
process.
