### PR TITLE
Fix lint error that occurred on rubocop 0.45.0

### DIFF
--- a/app/dependency_file_updaters/ruby.rb
+++ b/app/dependency_file_updaters/ruby.rb
@@ -86,10 +86,9 @@ module DependencyFileUpdaters
         end
       end
     rescue SharedHelpers::ChildProcessFailed => error
-      if error.error_class == "Bundler::VersionConflict"
-        raise DependencyFileUpdaters::VersionConflict
-      else raise
-      end
+      raise DependencyFileUpdaters::VersionConflict \
+        if error.error_class == "Bundler::VersionConflict"
+      raise
     end
 
     def write_temporary_dependency_files_to(dir)


### PR DESCRIPTION
The branch bump_rubocop_to_0.45.0 in #137 had this as a linting error with latest Rubocop.

This PR fixes [the linting issue](https://travis-ci.org/gocardless/bump/builds/172197780#L226), so that latest Rubocop can be used.

Here is the output linked above:

```
Inspecting 49 files
...........C.....................................
Offenses:
app/dependency_file_updaters/ruby.rb:89:7: C: Style/GuardClause: Use a guard clause instead of wrapping the code inside a conditional expression.
      if error.error_class == "Bundler::VersionConflict"
      ^^
49 files inspected, 1 offense detected

```

The change is to follow the advice of the cop and turn that block of code into a guard clause instead.