### PR TITLE
Use the default rake task on Travis to run CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 sudo: false
 
 bundler_args: ''
+before_install:
+ - gem update --system
+ - gem install bundler
 
-script:
-  - bundle exec rubocop
-  - bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,12 @@
 ruby "2.2.4"
 source "https://rubygems.org"
 
-gem "bundler", "~> 1.12.5"
+gem "bundler", "~> 1.13.6"
 gem "gemnasium-parser", "~> 0.1.9"
 gem "gems", "~> 0.8.3"
 gem "octokit", "~> 4.3.0"
 gem "prius", "~> 1.0.0"
+gem "rake"
 gem "sentry-raven", "~> 2.1.4"
 gem "sidekiq", "~> 4.2.7"
 gem "sinatra"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ GEM
     rack-protection (1.5.3)
       rack
     rainbow (2.1.0)
+    rake (11.3.0)
     redis (3.3.2)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -79,7 +80,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.12.5)
+  bundler (~> 1.13.6)
   dotenv
   foreman (~> 0.82.0)
   gemnasium-parser (~> 0.1.9)
@@ -87,6 +88,7 @@ DEPENDENCIES
   highline (~> 1.7.8)
   octokit (~> 4.3.0)
   prius (~> 1.0.0)
+  rake
   rspec (~> 3.5.0)
   rspec-its (~> 1.2.0)
   rubocop (~> 0.46.0)
@@ -99,4 +101,4 @@ RUBY VERSION
    ruby 2.2.4p230
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,8 @@
+require "rubocop/rake_task"
+RuboCop::RakeTask.new
+
+require "rspec/core/rake_task"
+RSpec::Core::RakeTask.new(:spec)
+
+# This is run by default by Travis
+task default: [:rubocop, :spec]


### PR DESCRIPTION
- use the default Rake task to run CI
- update Rubygems and Bundler in CI
- adds rake to Gemfile, changes bundler ver to latest