### PR TITLE
Generate a compare(old, new) URL for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,11 @@ language: ruby
 
 sudo: false
 
+branches:
+  only:
+    - "master"
+
 bundler_args: ''
 before_install:
  - gem update --system
  - gem install bundler
-

--- a/app/dependency.rb
+++ b/app/dependency.rb
@@ -4,16 +4,18 @@ require "./app/dependency_source_code_finders/ruby"
 require "./app/dependency_source_code_finders/node"
 
 class Dependency
-  attr_reader :name, :version, :language
+  attr_reader :name, :version, :previous_version, :language
 
   CHANGELOG_NAMES = %w(changelog history news changes).freeze
   GITHUB_REGEX    = %r{github\.com/(?<repo>[^/]+/[^/]+)/?}
   SOURCE_KEYS     = %w(source_code_uri homepage_uri wiki_uri bug_tracker_uri
                        documentation_uri).freeze
+  TAG_PREFIX      = /^v/
 
-  def initialize(name:, version:, language: nil)
+  def initialize(name:, version:, previous_version: nil, language: nil)
     @name = name
     @version = version
+    @previous_version = previous_version
     @language = language
   end
 
@@ -26,6 +28,20 @@ class Dependency
   def github_repo_url
     return unless github_repo
     Github.client.web_endpoint + github_repo
+  end
+
+  def github_compare_url
+    return unless github_repo
+
+    @tags ||= look_up_repo_tags
+
+    if @tags.include?(previous_version) && @tags.include?(version)
+      "#{github_repo_url}/compare/v#{previous_version}...v#{version}"
+    elsif @tags.include?(version)
+      "#{github_repo_url}/commits/v#{version}"
+    else
+      "#{github_repo_url}/commits"
+    end
   end
 
   def changelog_url
@@ -51,6 +67,14 @@ class Dependency
     @changelog_url = file.nil? ? nil : file.html_url
   rescue Octokit::NotFound
     @changelog_url = nil
+  end
+
+  def look_up_repo_tags
+    Github.client.tags(github_repo).map do |tag|
+      tag["name"].to_s.gsub(TAG_PREFIX, "")
+    end
+  rescue Octokit::NotFound
+    []
   end
 
   def source_code_finder

--- a/app/pull_request_creator.rb
+++ b/app/pull_request_creator.rb
@@ -82,7 +82,12 @@ class PullRequestCreator
     end
 
     if dependency.github_repo_url
-      msg += "\n- [Commits](#{dependency.github_repo_url + '/commits'})"
+      title = if dependency.previous_version
+                "Changes since #{dependency.previous_version}"
+              else
+                "Commits"
+              end
+      msg += "\n- [#{title}](#{dependency.github_compare_url})"
     end
 
     msg

--- a/app/workers/dependency_file_updater.rb
+++ b/app/workers/dependency_file_updater.rb
@@ -16,7 +16,8 @@ module Workers
     def perform(body)
       updated_dependency = Dependency.new(
         name: body["updated_dependency"]["name"],
-        version: body["updated_dependency"]["version"]
+        version: body["updated_dependency"]["version"],
+        previous_version: body["updated_dependency"]["previous_version"]
       )
 
       dependency_files = body["dependency_files"].map do |file|

--- a/app/workers/pull_request_creator.rb
+++ b/app/workers/pull_request_creator.rb
@@ -18,6 +18,7 @@ module Workers
       updated_dependency = Dependency.new(
         name: body["updated_dependency"]["name"],
         version: body["updated_dependency"]["version"],
+        previous_version: body["updated_dependency"]["previous_version"],
         language: body["repo"]["language"]
       )
 

--- a/app/workers/update_checker.rb
+++ b/app/workers/update_checker.rb
@@ -27,10 +27,13 @@ module Workers
       )
       return unless update_checker.needs_update?
 
-      update_dependency(body["repo"],
-                        body["dependency_files"],
-                        Dependency.new(name: dependency.name,
-                                       version: update_checker.latest_version))
+      updated_dep = Dependency.new(
+        name: dependency.name,
+        version: update_checker.latest_version,
+        previous_version: update_checker.dependency_version.to_s
+      )
+
+      update_dependency(body["repo"], body["dependency_files"], updated_dep)
     rescue => error
       Raven.capture_exception(error, extra: { body: body })
       raise
@@ -44,7 +47,8 @@ module Workers
         "dependency_files" => dependency_files,
         "updated_dependency" => {
           "name" => updated_dependency.name,
-          "version" => updated_dependency.version
+          "version" => updated_dependency.version,
+          "previous_version" => updated_dependency.previous_version
         }
       )
     end

--- a/spec/app/pull_request_creator_spec.rb
+++ b/spec/app/pull_request_creator_spec.rb
@@ -12,7 +12,10 @@ RSpec.describe PullRequestCreator do
   end
 
   let(:dependency) do
-    Dependency.new(name: "business", version: "1.5.0", language: "ruby")
+    Dependency.new(name: "business",
+                   version: "1.5.0",
+                   previous_version: "1.4.0",
+                   language: "ruby")
   end
   let(:repo) { "gocardless/bump" }
   let(:files) { [gemfile, gemfile_lock] }
@@ -63,6 +66,10 @@ RSpec.describe PullRequestCreator do
     stub_request(:get, "#{business_repo_url}/contents/").
       to_return(status: 200,
                 body: fixture("github", "business_files.json"),
+                headers: json_header)
+    stub_request(:get, "#{business_repo_url}/tags").
+      to_return(status: 200,
+                body: fixture("github", "business_tags.json"),
                 headers: json_header)
     stub_request(:get, "https://rubygems.org/api/v1/gems/business.yaml").
       to_return(status: 200, body: fixture("rubygems_response.yaml"))
@@ -120,7 +127,8 @@ RSpec.describe PullRequestCreator do
             title: "Bump business to 1.5.0",
             body: "Bumps [business](#{dependency.github_repo_url}) to 1.5.0."\
                   "\n- [Changelog](#{dependency.changelog_url})"\
-                  "\n- [Commits](#{dependency.github_repo_url + '/commits'})"
+                  "\n- [Changes since 1.4.0](#{dependency.github_repo_url}/"\
+                    "compare/v1.4.0...v1.5.0)"
           }
         )
     end

--- a/spec/app/workers/dependency_file_updater_spec.rb
+++ b/spec/app/workers/dependency_file_updater_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Workers::DependencyFileUpdater do
       },
       "updated_dependency" => {
         "name" => "business",
-        "version" => "1.5.0"
+        "version" => "1.5.0",
+        "previous_version" => "1.4.0"
       },
       "dependency_files" => [
         { "name" => "Gemfile", "content" => fixture("Gemfile") },

--- a/spec/app/workers/pull_request_creator_spec.rb
+++ b/spec/app/workers/pull_request_creator_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Workers::PullRequestCreator do
       },
       "updated_dependency" => {
         "name" => "business",
-        "version" => "1.5.0"
+        "version" => "1.5.0",
+        "previous_version" => "1.4.0"
       },
       "updated_dependency_files" => [
         { "name" => "Gemfile", "content" => "xyz" },

--- a/spec/app/workers/update_checker_spec.rb
+++ b/spec/app/workers/update_checker_spec.rb
@@ -40,7 +40,8 @@ RSpec.describe Workers::UpdateChecker do
             "dependency_files" => body["dependency_files"],
             "updated_dependency" => {
               "name" => "business",
-              "version" => "1.5.0"
+              "version" => "1.5.0",
+              "previous_version" => "1.4.0"
             }
           )
         perform

--- a/spec/fixtures/github/business_tags.json
+++ b/spec/fixtures/github/business_tags.json
@@ -1,0 +1,29 @@
+[
+  {
+    "name": "v1.5.0",
+    "zipball_url": "https://api.github.com/repos/gocardless/business/zipball/v1.5.0",
+    "tarball_url": "https://api.github.com/repos/gocardless/business/tarball/v1.5.0",
+    "commit": {
+      "sha": "55d39bf3042fac0b770bca2bfb200cfdffcd0175",
+      "url": "https://api.github.com/repos/gocardless/business/commits/55d39bf3042fac0b770bca2bfb200cfdffcd0175"
+    }
+  },
+  {
+    "name": "v1.4.0",
+    "zipball_url": "https://api.github.com/repos/gocardless/business/zipball/v1.4.0",
+    "tarball_url": "https://api.github.com/repos/gocardless/business/tarball/v1.4.0",
+    "commit": {
+      "sha": "26f4887ec647493f044836363537e329d9d213aa",
+      "url": "https://api.github.com/repos/gocardless/business/commits/26f4887ec647493f044836363537e329d9d213aa"
+    }
+  },
+  {
+    "name": "v1.3.0",
+    "zipball_url": "https://api.github.com/repos/gocardless/business/zipball/v1.3.0",
+    "tarball_url": "https://api.github.com/repos/gocardless/business/tarball/v1.3.0",
+    "commit": {
+      "sha": "469dacb70fafd72ed9571748036642df0d0857fa",
+      "url": "https://api.github.com/repos/gocardless/business/commits/469dacb70fafd72ed9571748036642df0d0857fa"
+    }
+  }
+]


### PR DESCRIPTION
Most open source projects follow the convention of tagging their releases, as `v{version}` (e.g. `v1.4.0`). We can take advantage of this to generate comparison URLs, which show us more accurately the changes between two versions.

#### Examples

  If we have tags for the old and new version:

    https://github.com/org/repo/compare/v0.1.0...v0.2.0

  If we don't have a tag/knowledge of the previous version, we can still show just the commits in this release:

    https://github.com/org/repo/commits/v0.2.0

  If we don't have any tags, we can fallback to the old URL and just show /commits

    https://github.com/org/repo/commits