### PR TITLE
Handle scoped npm package names

### DIFF
--- a/app/update_checkers/node.rb
+++ b/app/update_checkers/node.rb
@@ -7,13 +7,19 @@ module UpdateCheckers
     def latest_version
       @latest_version ||=
         begin
-          url = URI("http://registry.npmjs.org/#{dependency.name}")
-          JSON.parse(Net::HTTP.get(url))["dist-tags"]["latest"]
+          JSON.parse(Net::HTTP.get(dependency_url))["dist-tags"]["latest"]
         end
     end
 
     def dependency_version
       Gem::Version.new(dependency.version)
+    end
+
+    private
+
+    def dependency_url
+      path = dependency.name.gsub("/", "%2F")
+      URI("http://registry.npmjs.org/#{path}")
     end
   end
 end

--- a/spec/app/dependency_file_updaters/ruby_spec.rb
+++ b/spec/app/dependency_file_updaters/ruby_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe DependencyFileUpdaters::Ruby do
       let(:gemfile_body) { fixture("gemfiles", "version_not_specified") }
 
       it "locks the updated gem to the latest version" do
-        expect(file.content).to include "business (1.7.0)"
+        expect(file.content).to include "business (1.8.0)"
       end
 
       it "doesn't change the version of the other (also outdated) gem" do

--- a/spec/app/update_checkers/node_spec.rb
+++ b/spec/app/update_checkers/node_spec.rb
@@ -26,6 +26,15 @@ RSpec.describe UpdateCheckers::Node do
       let(:dependency) { Dependency.new(name: "etag", version: "1.7.0") }
       it { is_expected.to be_falsey }
     end
+
+    context "for a scoped package name" do
+      before do
+        stub_request(:get, "http://registry.npmjs.org/@blep%2Fblep").
+          to_return(status: 200, body: fixture("npm_response.json"))
+      end
+      let(:dependency) { Dependency.new(name: "@blep/blep", version: "1.0.0") }
+      it { is_expected.to be_truthy }
+    end
   end
 
   describe "#latest_version" do


### PR DESCRIPTION
See https://docs.npmjs.com/misc/scope

The package "@gocardless/stubby" is an example of this.
http://registry.npmjs.org/@gocardless/stubby is a 404, but http://registry.npmjs.org/@gocardless%2Fstubby is 👌