### PR TITLE
Fix pull request messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .bundle/
 .env
+/tmp

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,0 @@
-require "rubocop/rake_task"
-RuboCop::RakeTask.new
-
-require "rspec/core/rake_task"
-RSpec::Core::RakeTask.new(:spec)
-
-# This is run by default by Travis
-task default: [:rubocop, :spec]

--- a/app/dependency.rb
+++ b/app/dependency.rb
@@ -55,7 +55,8 @@ class Dependency
     {
       "name" => name,
       "version" => version,
-      "previous_version" => previous_version
+      "previous_version" => previous_version,
+      "language" => language
     }
   end
 

--- a/app/dependency_file_parsers/ruby.rb
+++ b/app/dependency_file_parsers/ruby.rb
@@ -12,7 +12,11 @@ module DependencyFileParsers
       parser.dependencies.map do |dependency|
         next if dependency.requirement.requirements.count > 1
         version = dependency.requirement.to_s.match(/[\d\.]+/)[0]
-        Dependency.new(name: dependency.name, version: version)
+        Dependency.new(
+          name: dependency.name,
+          version: version,
+          language: "ruby"
+        )
       end.reject(&:nil?)
     end
 

--- a/app/dependency_source_code_finders/node.rb
+++ b/app/dependency_source_code_finders/node.rb
@@ -16,12 +16,11 @@ module DependencySourceCodeFinders
         all_versions.map { |v| v["homepage"] } +
         all_versions.map { |v| get_url(v.fetch("bugs", {})) }
 
-      potential_source_urls = potential_source_urls.reject(&:nil?)
+      potential_source_urls = potential_source_urls.compact
 
       source_url = potential_source_urls.find { |url| url =~ GITHUB_REGEX }
 
-      @github_repo =
-        source_url.nil? ? nil : source_url.match(GITHUB_REGEX)[:repo]
+      @github_repo = source_url.match(GITHUB_REGEX)[:repo] if source_url
     end
 
     def get_url(details)

--- a/app/dependency_source_code_finders/ruby.rb
+++ b/app/dependency_source_code_finders/ruby.rb
@@ -3,23 +3,26 @@ require "./app/dependency_source_code_finders/base"
 
 module DependencySourceCodeFinders
   class Ruby < Base
-    SOURCE_KEYS = %w(source_code_uri homepage_uri wiki_uri bug_tracker_uri
-                     documentation_uri).freeze
+    SOURCE_KEYS = %w(
+      source_code_uri
+      homepage_uri
+      wiki_uri
+      bug_tracker_uri
+      documentation_uri
+    ).freeze
 
     private
 
     def look_up_github_repo
       @github_repo_lookup_attempted = true
 
-      potential_source_urls =
-        Gems.info(dependency_name).select do |key, _|
-          SOURCE_KEYS.include?(key)
-        end.values
+      source_url = Gems.
+                   info(dependency_name).
+                   values_at(*SOURCE_KEYS).
+                   compact.
+                   find { |url| url =~ GITHUB_REGEX }
 
-      source_url = potential_source_urls.find { |url| url =~ GITHUB_REGEX }
-
-      @github_repo =
-        source_url.nil? ? nil : source_url.match(GITHUB_REGEX)[:repo]
+      @github_repo = source_url.match(GITHUB_REGEX)[:repo] if source_url
     end
   end
 end

--- a/app/update_checkers/base.rb
+++ b/app/update_checkers/base.rb
@@ -17,7 +17,8 @@ module UpdateCheckers
       Dependency.new(
         name: dependency.name,
         version: latest_version,
-        previous_version: dependency_version.to_s
+        previous_version: dependency_version.to_s,
+        language: language
       )
     end
 
@@ -26,6 +27,10 @@ module UpdateCheckers
     end
 
     def dependency_version
+      raise NotImplementedError
+    end
+
+    def language
       raise NotImplementedError
     end
   end

--- a/app/update_checkers/node.rb
+++ b/app/update_checkers/node.rb
@@ -21,5 +21,9 @@ module UpdateCheckers
       path = dependency.name.gsub("/", "%2F")
       URI("http://registry.npmjs.org/#{path}")
     end
+
+    def language
+      "node"
+    end
   end
 end

--- a/app/update_checkers/ruby.rb
+++ b/app/update_checkers/ruby.rb
@@ -22,5 +22,9 @@ module UpdateCheckers
       raise "No Gemfile.lock!" unless lockfile
       lockfile
     end
+
+    def language
+      "ruby"
+    end
   end
 end

--- a/app/workers/dependency_file_fetcher.rb
+++ b/app/workers/dependency_file_fetcher.rb
@@ -29,10 +29,7 @@ module Workers
         Workers::DependencyUpdater.perform_async(
           "repo" => repo.to_h.merge("commit" => file_fetcher.commit),
           "dependency_files" => file_fetcher.files.map(&:to_h),
-          "dependency" => {
-            "name" => dependency.name,
-            "version" => dependency.version
-          }
+          "dependency" => dependency.to_h
         )
       end
 

--- a/spec/app/workers/dependency_file_fetcher_spec.rb
+++ b/spec/app/workers/dependency_file_fetcher_spec.rb
@@ -44,7 +44,9 @@ RSpec.describe Workers::DependencyFileFetcher do
           ],
           "dependency" => {
             "name" => "business",
-            "version" => "1.4.0"
+            "version" => "1.4.0",
+            "language" => "ruby",
+            "previous_version" => nil
           }
         )
 
@@ -58,7 +60,9 @@ RSpec.describe Workers::DependencyFileFetcher do
           ],
           "dependency" => {
             "name" => "statesman",
-            "version" => "1.2.0"
+            "version" => "1.2.0",
+            "language" => "ruby",
+            "previous_version" => nil
           }
         )
 

--- a/spec/app/workers/dependency_updater_spec.rb
+++ b/spec/app/workers/dependency_updater_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Workers::DependencyUpdater do
       },
       "dependency" => {
         "name" => "business",
-        "version" => "1.4.0"
+        "version" => "1.4.0",
+        "language" => "ruby"
       },
       "dependency_files" => [
         { "name" => "Gemfile", "content" => fixture("Gemfile") },
@@ -44,7 +45,8 @@ RSpec.describe Workers::DependencyUpdater do
           expect(args[:dependency].to_h).to eq(
             "name" => "business",
             "version" => "1.5.0",
-            "previous_version" => "1.4.0"
+            "previous_version" => "1.4.0",
+            "language" => "ruby"
           )
           expect(args[:files].map(&:to_h)).to eq(
             [{ "name" => "Gemfile", "content" => "xyz" }]


### PR DESCRIPTION
### Problem

Looks like Bump has stopped providing detailed context in PRs.

<img width="681" alt="bump-no-details" src="https://cloud.githubusercontent.com/assets/661795/23410098/fb5a7cf4-fdc5-11e6-9f3c-7fd4b1463613.png">

### Cause

I think this is because `language` is no longer being set on an individual `Dependency` object, and therefore we never try to contact Github to resolve more details about the change: https://github.com/gocardless/bump/blob/23b63f996308f8eb4d50d2b3b3e64f3fa4b01d2b/app/dependency.rb#L23

### Solution

* Use the new `Dependency#to_h` method when serializing/deserializing these instances. This might lead to passing around `nil` keys (we could consider compacting the hash), but at least it's explicit about our apis are.

### Further discussion

* Repo has `#language` also. We could probably avoid duplication, and not also apply language to the `Dependency` object. @hmac thoughts?