### PR TITLE
Use open-uri for HTTP requests, so we follow redirects

### DIFF
--- a/app/dependency_source_code_finders/node.rb
+++ b/app/dependency_source_code_finders/node.rb
@@ -1,3 +1,4 @@
+require "open-uri"
 require "./app/dependency_source_code_finders/base"
 
 module DependencySourceCodeFinders
@@ -9,7 +10,7 @@ module DependencySourceCodeFinders
 
       npm_url = URI("http://registry.npmjs.org/#{dependency_name}")
       all_versions =
-        JSON.parse(Net::HTTP.get(npm_url)).fetch("versions", {}).values
+        JSON.parse(open(npm_url).read).fetch("versions", {}).values
 
       potential_source_urls =
         all_versions.map { |v| get_url(v.fetch("repository", {})) } +

--- a/app/dependency_source_code_finders/python.rb
+++ b/app/dependency_source_code_finders/python.rb
@@ -1,4 +1,5 @@
 require "gems"
+require "open-uri"
 require "./app/dependency_source_code_finders/base"
 
 module DependencySourceCodeFinders
@@ -8,7 +9,7 @@ module DependencySourceCodeFinders
     def look_up_github_repo
       @github_repo_lookup_attempted = true
       pypi_url = URI("https://pypi.python.org/pypi/#{dependency_name}/json")
-      package = JSON.parse(Net::HTTP.get(pypi_url))
+      package = JSON.parse(open(pypi_url).read)
 
       all_versions = package.fetch("releases", {}).values
       info = package.fetch("info", {})

--- a/app/update_checkers/node.rb
+++ b/app/update_checkers/node.rb
@@ -1,13 +1,13 @@
 require "./app/update_checkers/base"
 require "json"
-require "net/http"
+require "open-uri"
 
 module UpdateCheckers
   class Node < Base
     def latest_version
       @latest_version ||=
         begin
-          JSON.parse(Net::HTTP.get(dependency_url))["dist-tags"]["latest"]
+          JSON.parse(open(dependency_url).read)["dist-tags"]["latest"]
         end
     end
 

--- a/app/update_checkers/python.rb
+++ b/app/update_checkers/python.rb
@@ -1,5 +1,5 @@
 require "./app/update_checkers/base"
-require "net/http"
+require "open-uri"
 
 module UpdateCheckers
   class Python < Base
@@ -7,7 +7,7 @@ module UpdateCheckers
       @latest_version ||=
         begin
           url = URI("https://pypi.python.org/pypi/#{dependency.name}/json")
-          JSON.parse(Net::HTTP.get(url))["info"]["version"]
+          JSON.parse(open(url).read)["info"]["version"]
         end
     end
 

--- a/spec/app/dependency_source_code_finders/python_spec.rb
+++ b/spec/app/dependency_source_code_finders/python_spec.rb
@@ -35,5 +35,20 @@ RSpec.describe DependencySourceCodeFinders::Python do
         expect(WebMock).to have_requested(:get, pypi_url).once
       end
     end
+
+    context "when the link resolves to a redirect" do
+      let(:pypi_url) { "https://pypi.python.org/pypi/luigi/json" }
+      let(:redirect_url) { "https://pypi.python.org/pypi/LuiGi/json" }
+      let(:pypi_response) { fixture("pypi_response.json") }
+
+      before do
+        stub_request(:get, pypi_url).
+          to_return(status: 302, headers: { "Location" => redirect_url })
+        stub_request(:get, redirect_url).
+          to_return(status: 200, body: pypi_response)
+      end
+
+      it { is_expected.to eq("spotify/luigi") }
+    end
   end
 end


### PR DESCRIPTION
Fixes https://exceptions.gocardless.com/gocardless/bump/issues/7723