### PR TITLE
Don't output to STDOUT when performing node bumps

### DIFF
--- a/app/dependency_file_updaters/node.rb
+++ b/app/dependency_file_updaters/node.rb
@@ -63,7 +63,7 @@ module DependencyFileUpdaters
       SharedHelpers.in_a_temporary_directory do |dir|
         File.write(File.join(dir, "yarn.lock"), @yarn_lock.content)
         File.write(File.join(dir, "package.json"), updated_package_json_content)
-        puts `cd #{dir} && yarn install --ignore-scripts`
+        `cd #{dir} && yarn install --ignore-scripts 2>&1`
         @updated_yarn_lock_content =
           File.read(File.join(dir, "yarn.lock"))
       end

--- a/spec/app/dependency_file_updaters/node_spec.rb
+++ b/spec/app/dependency_file_updaters/node_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe DependencyFileUpdaters::Node do
   describe "#updated_dependency_files" do
     subject(:updated_files) { updater.updated_dependency_files }
     specify { expect { updated_files }.to_not change { Dir.entries(tmp_path) } }
+    specify { expect { updated_files }.to_not output.to_stdout }
     specify { updated_files.each { |f| expect(f).to be_a(DependencyFile) } }
     its(:length) { is_expected.to eq(2) }
   end


### PR DESCRIPTION
We don't want to hear about Yarn's progress - no-one's watching STDOUT when it runs anyway.

Returns specs to being an uninterrupted sea of green.