### PR TITLE
Don't strip full stops from Github link URLs

### DIFF
--- a/app/dependency.rb
+++ b/app/dependency.rb
@@ -9,9 +9,6 @@ class Dependency
   attr_reader :name, :version, :previous_version, :language
 
   CHANGELOG_NAMES = %w(changelog history news changes).freeze
-  GITHUB_REGEX    = %r{github\.com/(?<repo>[^/]+/[^/]+)/?}
-  SOURCE_KEYS     = %w(source_code_uri homepage_uri wiki_uri bug_tracker_uri
-                       documentation_uri).freeze
   TAG_PREFIX      = /^v/
 
   def initialize(name:, version:, previous_version: nil, language: nil)

--- a/app/dependency_source_code_finders/base.rb
+++ b/app/dependency_source_code_finders/base.rb
@@ -3,7 +3,7 @@ require "gems"
 
 module DependencySourceCodeFinders
   class Base
-    GITHUB_REGEX = %r{github\.com/(?<repo>[^/]+/[^\./]+)[\./]?}
+    GITHUB_REGEX = %r{github\.com/(?<repo>[^/]+/(?:(?!\.git)[^/])+)[\./]?}
 
     attr_reader :dependency_name
 

--- a/spec/app/dependency_source_code_finders/ruby_spec.rb
+++ b/spec/app/dependency_source_code_finders/ruby_spec.rb
@@ -24,6 +24,14 @@ RSpec.describe DependencySourceCodeFinders::Ruby do
         2.times { github_repo }
         expect(WebMock).to have_requested(:get, rubygems_url).once
       end
+
+      context "that contains a .git suffix" do
+        let(:rubygems_response) do
+          fixture("rubygems_response_period_github.yaml")
+        end
+
+        it { is_expected.to eq("gocardless/business.rb") }
+      end
     end
 
     context "when there isn't github link in the rubygems response" do

--- a/spec/fixtures/rubygems_response_period_github.yaml
+++ b/spec/fixtures/rubygems_response_period_github.yaml
@@ -1,0 +1,27 @@
+---
+name: business
+downloads: 18626
+version: 1.5.0
+version_downloads: 2676
+platform: ruby
+authors: Harry Marr
+info: Date calculations based on business calendars
+licenses:
+- MIT
+metadata: {}
+sha: 5293b3f6e9b5db12d8b0ee36c2df1f1592aaff49ce961c1c11d035a72e2f9a77
+project_uri: https://rubygems.org/gems/business
+gem_uri: https://rubygems.org/gems/business-1.5.0.gem
+homepage_uri: https://github.com/gocardless/business.rb/homepage
+wiki_uri:
+documentation_uri: http://www.rubydoc.info/gems/business/1.5.0
+mailing_list_uri:
+source_code_uri:
+bug_tracker_uri:
+dependencies:
+  development:
+  - name: bundler
+    requirements: "~> 1.3"
+  - name: rspec
+    requirements: "~> 3.0"
+  runtime: []


### PR DESCRIPTION
Github allows full stops in repo names. For example, see https://github.com/octokit/octokit.rb

Also removes some unused constants.