### PR TITLE
Add spec for preserving Gemfile comments

### DIFF
--- a/spec/fixtures/gemfiles/comments
+++ b/spec/fixtures/gemfiles/comments
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"   # Business time
+gem "statesman", "~> 1.2.0"  # State machine

--- a/spec/lib/dependency_file_updaters/ruby_spec.rb
+++ b/spec/lib/dependency_file_updaters/ruby_spec.rb
@@ -69,6 +69,13 @@ RSpec.describe Bump::DependencyFileUpdaters::Ruby do
       let(:dependency) { Bump::Dependency.new(name: "i18n", version: "1.5.0") }
       its(:content) { is_expected.to include "\"i18n\", \"~> 1.5.0\"" }
     end
+
+    context "when there is a comment" do
+      let(:gemfile_body) { fixture("gemfiles", "comments") }
+      its(:content) do
+        is_expected.to include "\"business\", \"~> 1.5.0\"   # Business time"
+      end
+    end
   end
 
   describe "#updated_gemfile_lock" do


### PR DESCRIPTION
Ensures we're not accidentally nuking comments from Gemfiles.