### PR TITLE
Add a gemspec, and move core dependencies there

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-.bundle/
-.env
+/.bundle/
+/.env
 /tmp
+/bump-*.gem

--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,10 @@
 ruby "2.3.3"
 source "https://rubygems.org"
 
-gem "bundler", "~> 1.14.3"
-gem "excon"
-gem "gemnasium-parser", "~> 0.1.9"
-gem "gems", "~> 1.0.0"
-gem "octokit", "~> 4.6.2"
+# Dependencies necessary for using bump as a library are in the gemspec
+gemspec
+
+# Dependencies necessary for running bump as an app are here
 gem "prius", "~> 1.0.0"
 gem "rake"
 gem "sentry-raven", "~> 2.1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+PATH
+  remote: .
+  specs:
+    bump (0.1.0)
+      bundler (~> 1.14)
+      excon (~> 0.55)
+      gemnasium-parser (~> 0.1)
+      gems (~> 1.0)
+      octokit (~> 4.6)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -83,14 +93,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.14.3)
+  bump!
   dotenv
-  excon
   foreman (~> 0.82.0)
-  gemnasium-parser (~> 0.1.9)
-  gems (~> 1.0.0)
   highline (~> 1.7.8)
-  octokit (~> 4.6.2)
   prius (~> 1.0.0)
   rake
   rspec (~> 3.5.0)

--- a/bump.gemspec
+++ b/bump.gemspec
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+# coding: utf-8
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "English"
+require "bump/version"
+
+summary = "Automated dependency management for Ruby, Python and Javascript"
+
+Gem::Specification.new do |spec|
+  spec.name          = "bump"
+  spec.version       = Bump::VERSION
+  spec.authors       = ["GoCardless"]
+  spec.email         = ["engineering@gocardless.com"]
+  spec.summary       = summary
+  spec.description   = summary
+  spec.homepage      = "https://github.com/gocardless/bump"
+  spec.licenses      = ["MIT"]
+
+  spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ["lib"]
+
+  spec.add_dependency "bundler", "~> 1.14"
+  spec.add_dependency "excon", "~> 0.55"
+  spec.add_dependency "gemnasium-parser", "~> 0.1"
+  spec.add_dependency "gems", "~> 1.0"
+  spec.add_dependency "octokit", "~> 4.6"
+end


### PR DESCRIPTION
The Gemfile now only contains dependencies necessary for running the self-hosted version of bump.