### PR TITLE
Skip gems that aren't in the lockfile

### DIFF
--- a/lib/bump/update_checkers/base.rb
+++ b/lib/bump/update_checkers/base.rb
@@ -12,6 +12,7 @@ module Bump
       end
 
       def needs_update?
+        return false if dependency_version.nil?
         Gem::Version.new(latest_version) > dependency_version
       end
 

--- a/lib/bump/update_checkers/ruby.rb
+++ b/lib/bump/update_checkers/ruby.rb
@@ -17,9 +17,13 @@ module Bump
           return Gem::Version.new(Bundler::VERSION)
         end
 
+        # The safe navigation operator is necessary because not all files in
+        # the Gemfile will appear in the Gemfile.lock. For instance, if a gem
+        # specifies `platform: [:windows]`, and the Gemfile.lock is generated
+        # on a Linux machine, the gem will be not appear in the lockfile.
         parsed_lockfile.
           specs.
-          find { |spec| spec.name == dependency.name }.
+          find { |spec| spec.name == dependency.name }&.
           version
       end
 

--- a/spec/lib/update_checkers/ruby_spec.rb
+++ b/spec/lib/update_checkers/ruby_spec.rb
@@ -40,6 +40,11 @@ RSpec.describe Bump::UpdateCheckers::Ruby do
       it { is_expected.to be_falsey }
     end
 
+    context "given a dependency that doesn't appear in the lockfile" do
+      let(:dependency) { Bump::Dependency.new(name: "x", version: "1.0") }
+      it { is_expected.to be_falsey }
+    end
+
     context "given an out-of-date bundler as a dependency" do
       before { allow(checker).to receive(:latest_version).and_return("10.0.0") }
       let(:dependency) do


### PR DESCRIPTION
Not all files in the Gemfile will appear in the Gemfile.lock. For instance, if a gem specifies `platform: [:windows]`, and the Gemfile.lock is generated on a Linux machine, the gem will be not appear
in the lockfile.

Previously we would blow up in this case, now we just skip over the gem.