### PR TITLE
Allow any Bundler version >= 1.12.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     bump (0.1.0)
-      bundler (~> 1.14)
+      bundler (>= 1.12.0)
       excon (~> 0.55)
       gemnasium-parser (~> 0.1)
       gems (~> 1.0)

--- a/bump.gemspec
+++ b/bump.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "bundler", "~> 1.14"
+  spec.add_dependency "bundler", ">= 1.12.0"
   spec.add_dependency "excon", "~> 0.55"
   spec.add_dependency "gemnasium-parser", "~> 0.1"
   spec.add_dependency "gems", "~> 1.0"


### PR DESCRIPTION
Heroku only permits specific bundler versions that work with their
environment, so we can't be too picky about the version we want.