### PR TITLE
Bump bump-core to 0.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,9 @@
 ruby "2.3.3"
 source "https://rubygems.org"
 
-gem "bump-core", "~> 0.1.0",
+gem "bump-core", "~> 0.1.1",
     git: "https://github.com/gocardless/bump-core",
-    tag: "v0.1.0"
+    tag: "v0.1.1"
 gem "prius", "~> 1.0.0"
 gem "rake"
 gem "sentry-raven", "~> 2.4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/gocardless/bump-core
-  revision: 52a8c092183139b10ed16d86f66e716259ec4ce1
-  tag: v0.1.0
+  revision: c4b8876b2aa17e794a54319b1cd003d1933890da
+  tag: v0.1.1
   specs:
-    bump-core (0.1.0)
+    bump-core (0.1.1)
       bundler (>= 1.12.0)
       excon (~> 0.55)
       gemnasium-parser (~> 0.1)
@@ -97,7 +97,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bump-core (~> 0.1.0)!
+  bump-core (~> 0.1.1)!
   dotenv
   foreman (~> 0.84.0)
   highline (~> 1.7.8)


### PR DESCRIPTION
This fixes an issue where we're not following pypi redirects for some python packages.