### PR TITLE
Use latest version of bump-core

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,9 @@
 ruby "2.3.3"
 source "https://rubygems.org"
 
-gem "bump-core", "~> 0.1.1",
+gem "bump-core", "~> 0.3.3",
     git: "https://github.com/gocardless/bump-core",
-    tag: "v0.1.1"
+    tag: "v0.3.3"
 gem "prius", "~> 1.0.0"
 gem "rake"
 gem "sentry-raven", "~> 2.4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/gocardless/bump-core
-  revision: c4b8876b2aa17e794a54319b1cd003d1933890da
-  tag: v0.1.1
+  revision: d0d4faef498b9430b5879432001359cf66ea975b
+  tag: v0.3.3
   specs:
-    bump-core (0.1.1)
+    bump-core (0.3.3)
       bundler (>= 1.12.0)
       excon (~> 0.55)
       gemnasium-parser (~> 0.1)
@@ -23,7 +23,7 @@ GEM
     diff-lcs (1.3)
     dotenv (2.2.1)
     excon (0.55.0)
-    faraday (0.12.0.1)
+    faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
     foreman (0.84.0)
       thor (~> 0.19.1)
@@ -99,7 +99,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bump-core (~> 0.1.1)!
+  bump-core (~> 0.3.3)!
   dotenv
   foreman (~> 0.84.0)
   highline (~> 1.7.8)

--- a/app/workers/dependency_file_fetcher.rb
+++ b/app/workers/dependency_file_fetcher.rb
@@ -2,12 +2,8 @@
 require "sidekiq"
 require "./app/boot"
 require "bump/dependency_file"
-require "bump/dependency_file_fetchers/ruby"
-require "bump/dependency_file_fetchers/node"
-require "bump/dependency_file_fetchers/python"
-require "bump/dependency_file_parsers/ruby"
-require "bump/dependency_file_parsers/node"
-require "bump/dependency_file_parsers/python"
+require "bump/dependency_file_fetchers"
+require "bump/dependency_file_parsers"
 
 $stdout.sync = true
 
@@ -55,21 +51,11 @@ module Workers
     end
 
     def file_fetcher_for(language)
-      case language
-      when "ruby" then Bump::DependencyFileFetchers::Ruby
-      when "node" then Bump::DependencyFileFetchers::Node
-      when "python" then Bump::DependencyFileFetchers::Python
-      else raise "Invalid language #{language}"
-      end
+      Bump::DependencyFileFetchers.for_language(language)
     end
 
     def parser_for(language)
-      case language
-      when "ruby" then Bump::DependencyFileParsers::Ruby
-      when "node" then Bump::DependencyFileParsers::Node
-      when "python" then Bump::DependencyFileParsers::Python
-      else raise "Invalid language #{language}"
-      end
+      Bump::DependencyFileParsers.for_language(language)
     end
 
     def github_client

--- a/bin/bump_dependencies_for_repo
+++ b/bin/bump_dependencies_for_repo
@@ -22,7 +22,7 @@ repo_validator = lambda do |repo_name|
   end
 end
 
-language_validator = ->(l) { %w(ruby node python).include?(l) }
+language_validator = ->(l) { %w(ruby javascript python).include?(l) }
 
 if ARGV.empty?
   repo =
@@ -37,7 +37,7 @@ if ARGV.empty?
   language = ARGV[1] || choose do |menu|
     menu.header = "Which language would you like to bump dependencies for?"
     menu.index = :none
-    menu.choices(:ruby, :node, :python)
+    menu.choices(:ruby, :javascript, :python)
   end
 else
   repo = ARGV[0]

--- a/spec/app/workers/dependency_file_fetcher_spec.rb
+++ b/spec/app/workers/dependency_file_fetcher_spec.rb
@@ -43,8 +43,16 @@ RSpec.describe Workers::DependencyFileFetcher do
         with(
           "repo" => body["repo"].merge("commit" => "commitsha"),
           "dependency_files" => [
-            { "name" => "Gemfile", "content" => fixture("Gemfile") },
-            { "name" => "Gemfile.lock", "content" => fixture("Gemfile.lock") }
+            {
+              "name" => "Gemfile",
+              "content" => fixture("Gemfile"),
+              "directory" => "/"
+            },
+            {
+              "name" => "Gemfile.lock",
+              "content" => fixture("Gemfile.lock"),
+              "directory" => "/"
+            }
           ],
           "dependency" => {
             "name" => "business",
@@ -59,8 +67,16 @@ RSpec.describe Workers::DependencyFileFetcher do
         with(
           "repo" => body["repo"].merge("commit" => "commitsha"),
           "dependency_files" => [
-            { "name" => "Gemfile", "content" => fixture("Gemfile") },
-            { "name" => "Gemfile.lock", "content" => fixture("Gemfile.lock") }
+            {
+              "name" => "Gemfile",
+              "content" => fixture("Gemfile"),
+              "directory" => "/"
+            },
+            {
+              "name" => "Gemfile.lock",
+              "content" => fixture("Gemfile.lock"),
+              "directory" => "/"
+            }
           ],
           "dependency" => {
             "name" => "statesman",

--- a/spec/app/workers/dependency_updater_spec.rb
+++ b/spec/app/workers/dependency_updater_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Workers::DependencyUpdater do
             "language" => "ruby"
           )
           expect(args[:files].map(&:to_h)).to eq(
-            [{ "name" => "Gemfile", "content" => "xyz" }]
+            [{ "name" => "Gemfile", "content" => "xyz", "directory" => "/" }]
           )
         end.and_return(double(create: nil))
         perform
@@ -81,7 +81,7 @@ RSpec.describe Workers::DependencyUpdater do
         before do
           allow_any_instance_of(Bump::DependencyFileUpdaters::Ruby).
             to receive(:updated_dependency_files).
-            and_raise(Bump::DependencyFileUpdaters::VersionConflict)
+            and_raise(Bump::VersionConflict)
         end
 
         it "quietly finishes" do


### PR DESCRIPTION
`bump-core` v0.3.3 introduced some JavaScript bug fixes it would be a shame for GoCardless not to be taking advantage of. In particularly, you probably haven't been seeing changelogs for any of your JavaScript dependency bumps when you should have been.

This PR moves `bump` to use the latest version of `bump-core`. Once merged, you should also update any scheduled jobs on Heroku to use `javascript` as the language, rather than `node`.

✌️ 