### PR TITLE
Use bump-core 0.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,9 @@
 ruby "2.3.3"
 source "https://rubygems.org"
 
-gem "bump-core", "~> 0.3.3",
+gem "bump-core", "~> 0.4.1",
     git: "https://github.com/gocardless/bump-core",
-    tag: "v0.3.3"
+    tag: "v0.4.1"
 gem "prius", "~> 1.0.0"
 gem "rake"
 gem "sentry-raven", "~> 2.4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/gocardless/bump-core
-  revision: d0d4faef498b9430b5879432001359cf66ea975b
-  tag: v0.3.3
+  revision: 628c220dccc4fee18135c3133cc3f5bf3f630d8a
+  tag: v0.4.1
   specs:
-    bump-core (0.3.3)
+    bump-core (0.4.1)
       bundler (>= 1.12.0)
       excon (~> 0.55)
       gemnasium-parser (~> 0.1)
@@ -99,7 +99,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bump-core (~> 0.3.3)!
+  bump-core (~> 0.4.1)!
   dotenv
   foreman (~> 0.84.0)
   highline (~> 1.7.8)


### PR DESCRIPTION
No reason for you guys not to be on the latest bump-core. Only breaking change in there was to make `language` required for `Bump::Dependency`, but you don't create those manually anywhere anyway.

https://github.com/gocardless/bump-core/blob/master/CHANGELOG.md