### PR TITLE
Update bump-core to v0.5.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,9 @@
 ruby "2.3.3"
 source "https://rubygems.org"
 
-gem "bump-core", "~> 0.5.0",
+gem "bump-core",
     git: "https://github.com/gocardless/bump-core",
-    tag: "v0.5.0"
+    tag: "v0.5.5"
 gem "prius", "~> 1.0.0"
 gem "rake"
 gem "sentry-raven", "~> 2.5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/gocardless/bump-core
-  revision: 81d0a760f35bb2992343513bad7dd297f1a28103
-  tag: v0.5.0
+  revision: 4310658cc8a750b823c74f7c8363716bd1e127b6
+  tag: v0.5.5
   specs:
-    bump-core (0.5.0)
+    bump-core (0.5.5)
       bundler (>= 1.12.0)
       excon (~> 0.55)
       gemnasium-parser (~> 0.1)
@@ -99,7 +99,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bump-core (~> 0.5.0)!
+  bump-core!
   dotenv
   foreman (~> 0.84.0)
   highline (~> 1.7.8)
@@ -117,4 +117,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.14.6
+   1.15.0


### PR DESCRIPTION
`v0.5.1` introduced a new format for branch names, so any existing branches will need to be closed otherwise we'll get some dupes.