### PR TITLE
Update the README.md to reflect deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Bump
 
+**Bump has now been superseded by [Dependabot](www.dependabot.com), which we recommend for all your dependency updating needs**
+
 [![Build Status](https://circleci.com/gh/gocardless/bump/tree/master.svg?style=svg)](https://circleci.com/gh/gocardless/bump)
 
 Bump helps you keep your project's Ruby (Bundler), Node (Yarn) and Python (Pip) dependencies up to date. It:


### PR DESCRIPTION
We're now using [dependabot](http://www.dependabot.com) to keep our dependencies up to date, that means we're effectively deprecating the use of bump.

I don't think we should alter the README as I believe this is still relevant in the case where you'd like to host your own internal version of a dependency checker.

- [x] Merged on Friday, August 4th, 2017.