### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bump
 
-**Bump has now been superseded by [Dependabot](www.dependabot.com), which we recommend for all your dependency updating needs**
+**Bump has now been superseded by [Dependabot](https://dependabot.com), which we recommend for all your dependency updating needs**
 
 [![Build Status](https://circleci.com/gh/gocardless/bump/tree/master.svg?style=svg)](https://circleci.com/gh/gocardless/bump)
 


### PR DESCRIPTION
Just spotted this. Without the scheme it's considering it a relative link and linking to https://github.com/gocardless/bump/blob/master/www.dependabot.com!