### PR TITLE
Fix the specs by manipulating Bundler's settings differently

### DIFF
--- a/app/boot.rb
+++ b/app/boot.rb
@@ -19,4 +19,4 @@ end
 
 # Heroku's ruby buildpack freezes the Gemfile to prevent accidental damage
 # However, we actually *want* to manipulate Gemfiles for other repos.
-Bundler.settings[:frozen] = "0"
+Bundler.settings.temporary(frozen: 0)


### PR DESCRIPTION
In `app/boot.rb`, we try to set Bundler's settings to "unfreeze" the bundle for the purposes of our tests. This has been broken for a little while due to a changed API in Bundler since v1.16.0,
resulting in [errors when running the tests][circle-gocardless-bump-258]:

```
An error occurred while loading ./spec/app/workers/dependency_file_fetcher_spec.rb.
Failure/Error: Bundler.settings[:frozen] = "0"

NoMethodError:
  undefined method `[]=' for #<Bundler::Settings:0x00000002958f38>
  Did you mean?  []
```

Bundler removed this API for tweaking the settings in [June][8ccf49c], but an alternative means for updating them was introduced before that in [August 2016][3b6dd37].

This switches to using the way that is in Bundler now: using `Bundler::Settings#temporary`.

[circle-gocardless-bump-258]: https://circleci.com/gh/gocardless/bump/258?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
[8ccf49c]: https://github.com/bundler/bundler/commit/8ccf49c3b4a086f1e0cad2130dc30c04304175b7
[3b6dd37]: https://github.com/bundler/bundler/commit/3b6dd372dca9b695e9283d8c49644b9dec9ef260